### PR TITLE
Update nordhub.user.css (background fix)

### DIFF
--- a/nordhub.user.css
+++ b/nordhub.user.css
@@ -31,6 +31,7 @@
 
 body {
     background: var(--bg);
+    min-height: 100vh;
 }
 
 .Box, .color-bg-primary, .gh-header, .orghead, .Box-row--gray {

--- a/nordhub.user.css
+++ b/nordhub.user.css
@@ -59,6 +59,10 @@ body {
 a {
     color: var(--accent)
 }
+    
+a.no-underline {
+  color: var(--light-white);
+}
 
 .Header, .color-bg-secondary, .timeline-comment, .timeline-comment-header, .gh-header .gh-header-sticky.is-stuck + .gh-header-shadow, .header-search-wrapper, .jump-to-field-active, .color-bg-tertiary, .color-bg-canvas-inset, .markdown-body img, .rgh-clean-dashboard .js-news-feed-event-group, .rgh-clean-dashboard .dashboard .flex-items-baseline.py-3 {
     background: var(--bg) !important;

--- a/nordhub.user.css
+++ b/nordhub.user.css
@@ -61,7 +61,7 @@ a {
 }
     
 a.no-underline {
-  color: var(--light-white);
+  color: var(--text-color);
 }
 
 .Header, .color-bg-secondary, .timeline-comment, .timeline-comment-header, .gh-header .gh-header-sticky.is-stuck + .gh-header-shadow, .header-search-wrapper, .jump-to-field-active, .color-bg-tertiary, .color-bg-canvas-inset, .markdown-body img, .rgh-clean-dashboard .js-news-feed-event-group, .rgh-clean-dashboard .dashboard .flex-items-baseline.py-3 {


### PR DESCRIPTION
Hi,
This fixes an issue where the background looks like this:
<img width="500" alt="Screen Shot 2021-07-29 at 9 34 40 PM" src="https://user-images.githubusercontent.com/61983584/127586564-55a90b4b-8227-48a3-b5e8-9290ef3a448f.png">
It will extend the page to fit the full height of the screen even when the content can fit in less space than the full height.

The second commit fixes an issue where the repo's name in tag in a PR has the same color as the background (both var(--accent)).

Thank you so much for working on the theme!

-- Hello9999901
