### PR TITLE
nordhub.user.css:904: Missing curly bracket

### DIFF
--- a/nordhub.user.css
+++ b/nordhub.user.css
@@ -901,3 +901,4 @@ a.rgh-highest-rated-comment, .rgh-highest-rated-comment {
 .rgh-clean-dashboard .news > .f4 + div, .rgh-clean-dashboard .dashboard-rollup-items .body {
     border: none !important;
 }    
+}


### PR DESCRIPTION
Hi,  
I was not able to install the theme and I noticed that its due to a missing curly bracket at the end of the file @ line 904. the curly bracket is used to close the scope defined in line 13

```css
...
13: @-moz-document domain('github.com') {
...
904:  }
```

Thank you for making this great theme!

Edit: 
I belive this is the commit that intrudoced the issue 8edddf2